### PR TITLE
fix(ci): quote file paths in linux release upload step

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -346,8 +346,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ needs.create-release.outputs.release_tag }}" \
-            ${{ steps.linux_paths.outputs.appimage }} \
-            ${{ steps.linux_paths.outputs.deb }} \
+            "${{ steps.linux_paths.outputs.appimage }}" \
+            "${{ steps.linux_paths.outputs.deb }}" \
             --clobber
 
       - name: Upload to Release (Windows)


### PR DESCRIPTION
This PR fixes a build failure in the Linux release workflow. The `gh release upload` command was failing because the artifact filenames contained spaces (due to the product name "Timelapse Creator") and were not quoted. This change adds double quotes around the file path variables to ensure they are handled correctly by the shell.

---
*PR created automatically by Jules for task [4472160555238958050](https://jules.google.com/task/4472160555238958050) started by @animikhaich*