### PR TITLE
Fix macOS "App is damaged" error by distributing as tar.gz

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -327,18 +327,30 @@ jobs:
           echo "exe=$EXE" >> $GITHUB_OUTPUT
           echo "msi=$MSI" >> $GITHUB_OUTPUT
 
-      - name: Get artifact paths (macOS)
+      - name: Package macOS App
         if: matrix.platform == 'macos-latest'
         id: macos_paths
         run: |
-          DMG=$(find src-tauri/target -name '*.dmg' | head -1)
+          # Find the .app bundle
+          APP_PATH=$(find src-tauri/target -name "*.app" -type d | head -1)
           
-          if [ -z "$DMG" ]; then
-            echo "Error: Failed to locate macOS DMG artifact"
+          if [ -z "$APP_PATH" ]; then
+            echo "Error: Failed to locate macOS .app bundle"
             exit 1
           fi
           
-          echo "dmg=$DMG" >> $GITHUB_OUTPUT
+          echo "Found app at: $APP_PATH"
+
+          # Create tar.gz
+          APP_NAME=$(basename "$APP_PATH")
+          TAR_NAME="Timelapse-Creator_${{ matrix.target }}.tar.gz"
+
+          cd "$(dirname "$APP_PATH")"
+          tar -czf "$TAR_NAME" "$APP_NAME"
+
+          # Output the full path to the tar.gz
+          PKG_PATH="$(pwd)/$TAR_NAME"
+          echo "pkg=$PKG_PATH" >> $GITHUB_OUTPUT
 
       - name: Upload to Release (Linux)
         if: needs.create-release.outputs.release_tag != '' && matrix.platform == 'ubuntu-22.04'
@@ -367,5 +379,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ needs.create-release.outputs.release_tag }}" \
-            "${{ steps.macos_paths.outputs.dmg }}" \
+            "${{ steps.macos_paths.outputs.pkg }}" \
             --clobber

--- a/BUILD.md
+++ b/BUILD.md
@@ -106,7 +106,7 @@ The built executables will be in `src-tauri/target/release/bundle/`.
 | Platform | Output Location | Formats |
 |----------|-----------------|---------|
 | Windows | `target/release/bundle/msi/` | `.msi`, `.exe` |
-| macOS | `target/release/bundle/macos/` | `.app`, `.dmg` |
+| macOS | `target/release/bundle/macos/` | `.app`, `.dmg` (local) |
 | Linux | `target/release/bundle/` | `.AppImage`, `.deb`, `.rpm` |
 
 ## Cross-Compilation
@@ -235,14 +235,17 @@ When a release is created, the following artifacts are automatically built and a
 |----------|-------|
 | **Linux** | `.AppImage`, `.deb` |
 | **Windows** | `.exe`, `.msi` |
-| **macOS Intel** | `.dmg` |
-| **macOS ARM** | `.dmg` |
+| **macOS Intel** | `.tar.gz` |
+| **macOS ARM** | `.tar.gz` |
 
 ### macOS Code Signing
 
-The macOS builds are configured with `signingIdentity: null` to prevent "damaged and can't be opened" errors on unsigned builds. Users may need to:
-1. Right-click the app and select "Open"
-2. Or use: `xattr -cr /path/to/Timelapse\ Creator.app`
+The macOS builds are configured with `signingIdentity: null`. To avoid "damaged and can't be opened" errors that occur with unsigned `.dmg` files, the CI workflow packages the application as a `.tar.gz` archive.
+
+To run the app:
+1. Download and extract the `.tar.gz` file
+2. Drag `Timelapse Creator.app` to your Applications folder
+3. Right-click the app and select "Open" (first time only)
 
 For production releases with proper code signing, you'll need to:
 1. Set up Apple Developer certificates

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ For development:
 
 2. Run the executable
    - **Windows**: Double-click the `.exe` file
-   - **macOS**: Open the `.dmg` and drag to Applications
+   - **macOS**: Download `.tar.gz`, extract, move `.app` to Applications, and open.
    - **Linux**: Make the `.AppImage` executable and run it
 
 ### Development Setup
@@ -201,7 +201,7 @@ The built executables will be in `src-tauri/target/release/bundle/`.
 | Build Environment | Output Formats |
 |-------------------|---------------|
 | Windows | `.exe`, `.msi` |
-| macOS | `.app`, `.dmg` |
+| macOS | `.app`, `.dmg` (local), `.tar.gz` (release) |
 | Linux | `.AppImage`, `.deb`, `.rpm` |
 
 ## Tech Stack


### PR DESCRIPTION
Fixes the "App is damaged and can't be opened" error on macOS by changing the distribution format from DMG to tar.gz for unsigned builds. This avoids strict Gatekeeper checks on disk images. Updated CI workflow and documentation accordingly.

---
*PR created automatically by Jules for task [8363205158543272051](https://jules.google.com/task/8363205158543272051) started by @animikhaich*