### PR TITLE
Optimize build speed and update docs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -40,12 +40,6 @@ Timelapse Creator is built using:
 - Microsoft Visual Studio C++ Build Tools
 - WebView2 Runtime (usually pre-installed on Windows 10/11)
 
-#### macOS
-- Xcode Command Line Tools
-  ```bash
-  xcode-select --install
-  ```
-
 #### Linux
 - Build essentials and WebKit2GTK
   ```bash
@@ -106,7 +100,6 @@ The built executables will be in `src-tauri/target/release/bundle/`.
 | Platform | Output Location | Formats |
 |----------|-----------------|---------|
 | Windows | `target/release/bundle/msi/` | `.msi`, `.exe` |
-| macOS | `target/release/bundle/macos/` | `.app`, `.dmg` (local) |
 | Linux | `target/release/bundle/` | `.AppImage`, `.deb`, `.rpm` |
 
 ## Cross-Compilation
@@ -120,7 +113,6 @@ The repository includes a GitHub Actions workflow that automatically builds for 
 ```yaml
 # .github/workflows/build-release.yml will build on:
 # - windows-latest
-# - macos-latest
 # - ubuntu-22.04
 ```
 
@@ -144,8 +136,7 @@ The `Cargo.toml` includes release optimizations:
 ```toml
 [profile.release]
 panic = "abort"     # Smaller binary
-codegen-units = 1   # Better optimization
-lto = true          # Link-time optimization
+lto = "thin"        # Faster link-time optimization
 opt-level = "z"     # Optimize for size
 strip = true        # Strip symbols
 ```
@@ -224,7 +215,7 @@ The repository uses an automated CI/CD pipeline that creates releases when versi
    - The GitHub Actions workflow automatically triggers on version tags
    - Tests run first to ensure quality
    - A new GitHub Release is created with an auto-generated changelog
-   - Builds are created for all platforms (Linux, Windows, macOS Intel, macOS ARM)
+   - Builds are created for all platforms (Linux, Windows)
    - Built executables are automatically uploaded to the release
 
 ### Release Artifacts
@@ -235,22 +226,6 @@ When a release is created, the following artifacts are automatically built and a
 |----------|-------|
 | **Linux** | `.AppImage`, `.deb` |
 | **Windows** | `.exe`, `.msi` |
-| **macOS Intel** | `.tar.gz` |
-| **macOS ARM** | `.tar.gz` |
-
-### macOS Code Signing
-
-The macOS builds are configured with `signingIdentity: null`. To avoid "damaged and can't be opened" errors that occur with unsigned `.dmg` files, the CI workflow packages the application as a `.tar.gz` archive.
-
-To run the app:
-1. Download and extract the `.tar.gz` file
-2. Drag `Timelapse Creator.app` to your Applications folder
-3. Right-click the app and select "Open" (first time only)
-
-For production releases with proper code signing, you'll need to:
-1. Set up Apple Developer certificates
-2. Configure signing in `tauri.conf.json`
-3. Add signing secrets to GitHub Actions
 
 ### Changelog
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Time-lapse photography is a technique whereby the frequency at which film frames
 - ⚡ **Blazing Fast Performance** - Rust backend with FFmpeg for highly optimized video processing
 - 🎨 **Beautiful Native UI** - Modern, responsive interface that looks great on all platforms
 - 📦 **Small Bundle Size** - Tauri provides native-like apps with minimal footprint
-- 🖥️ **True Cross-Platform** - Works seamlessly on Windows, macOS, and Linux
+- 🖥️ **True Cross-Platform** - Works seamlessly on Windows and Linux
 
 ## Features
 
@@ -88,7 +88,6 @@ Pre-built executables are available for all major platforms:
 | Platform | Download | Requirements |
 |----------|----------|--------------|
 | Windows | [Download from latest release](https://github.com/animikhaich/Timelapse-Creator/releases/latest) | Windows 10+ |
-| macOS | [Download from latest release](https://github.com/animikhaich/Timelapse-Creator/releases/latest) | macOS 10.15+ |
 | Linux | [Download from latest release](https://github.com/animikhaich/Timelapse-Creator/releases/latest) | Modern Linux distros |
 
 **Note**: FFmpeg must be installed on your system for video processing.
@@ -139,7 +138,6 @@ For development:
 
 2. Run the executable
    - **Windows**: Double-click the `.exe` file
-   - **macOS**: Download `.tar.gz`, extract, move `.app` to Applications, and open.
    - **Linux**: Make the `.AppImage` executable and run it
 
 ### Development Setup
@@ -201,7 +199,6 @@ The built executables will be in `src-tauri/target/release/bundle/`.
 | Build Environment | Output Formats |
 |-------------------|---------------|
 | Windows | `.exe`, `.msi` |
-| macOS | `.app`, `.dmg` (local), `.tar.gz` (release) |
 | Linux | `.AppImage`, `.deb`, `.rpm` |
 
 ## Tech Stack

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,6 @@ tauri-plugin-opener = "2"
 
 [profile.release]
 panic = "abort"
-codegen-units = 1
-lto = true
+lto = "thin"
 opt-level = "z"
 strip = true


### PR DESCRIPTION
This change speeds up the release build process by relaxing some optimization constraints that have a high impact on compile time (LTO and codegen units) while maintaining size optimization. It also removes outdated references to macOS builds from the documentation.

---
*PR created automatically by Jules for task [9108412330757742385](https://jules.google.com/task/9108412330757742385) started by @animikhaich*