### PR TITLE
feat(tests): increase test coverage for frontend and backend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -113,7 +113,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -463,7 +462,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -487,7 +485,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2352,7 +2349,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
       "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2370,7 +2366,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2382,7 +2377,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2820,7 +2814,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4299,7 +4292,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -4843,7 +4835,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4920,7 +4911,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5141,7 +5131,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5154,7 +5143,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5801,7 +5789,6 @@
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -6111,7 +6098,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,11 +1,61 @@
 import '@testing-library/jest-dom';
-import { vi } from 'vitest';
+import { vi, beforeEach } from 'vitest';
 
 // Mock Tauri API
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }));
 
+// Store event listeners
+// We use a Map to store callbacks for each event name
+const eventListeners = new Map<string, Array<(event: any) => void>>();
+
 vi.mock('@tauri-apps/api/event', () => ({
-  listen: vi.fn(() => Promise.resolve(() => {})),
+  listen: vi.fn((event, callback) => {
+    const listeners = eventListeners.get(event) || [];
+    listeners.push(callback);
+    eventListeners.set(event, listeners);
+
+    // Return unlisten function
+    return Promise.resolve(() => {
+      const listeners = eventListeners.get(event) || [];
+      const index = listeners.indexOf(callback);
+      if (index > -1) {
+        listeners.splice(index, 1);
+      }
+    });
+  }),
 }));
+
+// Helper to trigger events
+// This allows tests to simulate backend events
+(global as any).mockEmit = (event: string, payload: any) => {
+  const listeners = eventListeners.get(event);
+  if (listeners) {
+    listeners.forEach((callback) => callback({ payload }));
+  }
+};
+
+// Mock pointer events for Radix UI
+window.PointerEvent = class PointerEvent extends Event {
+  constructor(type: string, props: PointerEventInit = {}) {
+    super(type, props);
+  }
+} as any;
+
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+window.HTMLElement.prototype.hasPointerCapture = vi.fn();
+
+// ResizeObserver mock
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// Clear listeners between tests
+beforeEach(() => {
+  eventListeners.clear();
+  vi.clearAllMocks();
+});

--- a/frontend/src/test/utils.test.ts
+++ b/frontend/src/test/utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from '../lib/utils';
+
+describe('cn utility', () => {
+  it('merges class names', () => {
+    expect(cn('class1', 'class2')).toBe('class1 class2');
+  });
+
+  it('handles conditional classes', () => {
+    expect(cn('class1', true && 'class2', false && 'class3')).toBe('class1 class2');
+  });
+
+  it('handles objects', () => {
+    expect(cn({ class1: true, class2: false, class3: true })).toBe('class1 class3');
+  });
+
+  it('merges tailwind classes correctly', () => {
+    // p-4 should overwrite p-2
+    expect(cn('p-2', 'p-4')).toBe('p-4');
+    // text-red-500 should overwrite text-blue-500
+    expect(cn('text-blue-500', 'text-red-500')).toBe('text-red-500');
+  });
+
+  it('handles arrays', () => {
+    expect(cn(['class1', 'class2'])).toBe('class1 class2');
+  });
+
+  it('handles nested arrays', () => {
+    expect(cn(['class1', ['class2', 'class3']])).toBe('class1 class2 class3');
+  });
+
+  it('handles undefined and null', () => {
+    expect(cn('class1', undefined, null, 'class2')).toBe('class1 class2');
+  });
+});

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -458,4 +458,64 @@ mod tests {
         let json = serde_json::to_string(&result);
         assert!(json.is_ok());
     }
+
+    #[test]
+    fn test_selection_result_roundtrip() {
+        let original = SelectionResult {
+            files: vec!["file1".to_string(), "file2".to_string()],
+            count: 2,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: SelectionResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(original.files, decoded.files);
+        assert_eq!(original.count, decoded.count);
+    }
+
+    #[test]
+    fn test_conversion_request_roundtrip() {
+        let original = ConversionRequest {
+            files: vec!["input.mp4".to_string()],
+            speed_multiplier: 100,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: ConversionRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(original.files, decoded.files);
+        assert_eq!(original.speed_multiplier, decoded.speed_multiplier);
+    }
+
+    #[test]
+    fn test_conversion_result_roundtrip() {
+        let original = ConversionResult {
+            success: false,
+            message: "Failed".to_string(),
+            converted_count: 0,
+            failed_count: 1,
+            output_files: vec![],
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: ConversionResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(original.success, decoded.success);
+        assert_eq!(original.message, decoded.message);
+        assert_eq!(original.converted_count, decoded.converted_count);
+        assert_eq!(original.failed_count, decoded.failed_count);
+        assert_eq!(original.output_files, decoded.output_files);
+    }
+
+    #[test]
+    fn test_progress_event_roundtrip() {
+        let original = ProgressEvent {
+            current_file: 5,
+            total_files: 10,
+            filename: "video.mp4".to_string(),
+            status: "Processing".to_string(),
+            output_path: Some("/out/video.mp4".to_string()),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: ProgressEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(original.current_file, decoded.current_file);
+        assert_eq!(original.total_files, decoded.total_files);
+        assert_eq!(original.filename, decoded.filename);
+        assert_eq!(original.status, decoded.status);
+        assert_eq!(original.output_path, decoded.output_path);
+    }
 }


### PR DESCRIPTION
This PR significantly increases the test coverage for both the frontend and backend of the application.

**Frontend Changes:**
- Enhanced `App.test.tsx` to test the full user flow including file selection, speed selection, conversion process, and error handling.
- Mocked Tauri's `invoke` and `listen` APIs to simulate backend responses and events.
- Added support for testing Radix UI components by mocking Pointer Events in JSDOM.
- Added unit tests for the `cn` utility function.

**Backend Changes:**
- Added unit tests for `video.rs` helper functions (`parse_fps`, `is_supported_format`, `get_output_path`) covering edge cases.
- Added unit tests for `parse_ffprobe_output` with mock JSON data to handle various ffprobe output scenarios.
- Added serialization/deserialization tests for command structs in `commands.rs`.

These changes ensure robust testing of critical paths and edge cases, improving the overall reliability of the application.

---
*PR created automatically by Jules for task [7198790263898526685](https://jules.google.com/task/7198790263898526685) started by @animikhaich*